### PR TITLE
Use $BASH rather than $SHELL to check for Bash as active shell

### DIFF
--- a/misc/build.func
+++ b/misc/build.func
@@ -74,7 +74,7 @@ msg_error() {
 
 # Check if the shell is using bash
 shell_check() {
-  if [[ "$(basename "$SHELL")" != "bash" ]]; then
+  if [[ "$(basename "$BASH")" != "bash" ]]; then
     clear
     msg_error "Your default shell is currently not set to Bash. To use these scripts, please switch to the Bash shell."
     echo -e "\nExiting..."

--- a/misc/build.func
+++ b/misc/build.func
@@ -76,7 +76,7 @@ msg_error() {
 shell_check() {
   if [[ "$(basename "$BASH")" != "bash" ]]; then
     clear
-    msg_error "Your default shell is currently not set to Bash. To use these scripts, please switch to the Bash shell."
+    msg_error "Your active shell is currently not set to Bash. To use these scripts, please switch to the Bash shell."
     echo -e "\nExiting..."
     sleep 2
     exit


### PR DESCRIPTION
## Description

To `$BASH` env var is set when Bash is the active shell. This is in contrast to `$SHELL`, which points to the user's default shell. For cases where the user's default shell isn't Bash, this allows for running the script using Bash, rather than requiring the user to change their default shell (using `chsh`) first.

Fixes #476

## Type of change
Please check the relevant option(s):

- [ ] Bug fix (non-breaking change that resolves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to change unexpectedly)
- [ ] New script (a fully functional and thoroughly tested script or set of scripts.)

## Prerequisites
The following efforts must be made for the PR to be considered. Please check when completed:
- [x] Self-review performed (I have reviewed my code, ensuring it follows established patterns and conventions)
- [x] Testing performed (I have tested my changes, ensuring everything works as expected)
- [ ] Documentation updated (I have updated any relevant documentation)
